### PR TITLE
Updating site link in README

### DIFF
--- a/README.md
+++ b/README.md
@@ -12,5 +12,5 @@ It's time to make extensions first class citizens of the PHP community
   
 ## Get Involved
 
-All the information you need is on our site <http://lornajane.github.io/gophp7-ext/>
+All the information you need is on our site <http://gophp7.org/gophp7-ext/>
 


### PR DESCRIPTION
I noticed that the link in `README.md` was returning a 404. I originally found the working site link thanks to [@ircmaxell's tweet](https://twitter.com/ircmaxell/status/571060722161078272). This PR updates the old link with the one in active use.