### PR TITLE
Add a blog

### DIFF
--- a/README.md
+++ b/README.md
@@ -8,3 +8,19 @@ To develop locally use:
     $ jekyll serve --baseurl /gophp7-ext
 
 which will serve the site at http://localhost:4000/gophp7-ext/
+
+## Blog posts
+
+To write a blog post, create a new file in the `_posts` directory. The file name must be of the format: `YYYY-MM-DD-url-of-post.md`.
+
+The start of the new file must contain "Yaml front matter". The minimum required is:
+
+    ---
+    title: Title of this blog post
+    ---
+    The content of the blog post goes here.
+
+    In multiple paragraphs.
+
+
+See http://jekyllrb.com/docs/posts/ for full details.

--- a/_config.yml
+++ b/_config.yml
@@ -7,3 +7,13 @@ navigation:
       url: /todo.html
     - text: Catalog
       url: /extensions-catalog.html
+    - text: Blog
+      url: /blog.html
+
+defaults:
+  -
+    scope:
+      path: ""
+      type: "posts"
+    values:
+      layout: "blog"

--- a/_layouts/blog.html
+++ b/_layouts/blog.html
@@ -40,8 +40,28 @@
 
     <!-- MAIN CONTENT -->
     <div id="main_content_wrap" class="outer">
-      <section id="main_content" class="inner">
+      <section id="main_content" class="inner blogpost">
+          <h1>{{ page.title }}</h1>
+          <div class="meta">{{ page.date| date: "%A %e %B %Y" }}</div>
           {{ content }}
+
+          <div class="prevnext">
+          {% if page.previous %}
+            <a href="{{ site.baseurl }}{{ page.previous.url }}">Previous</a>
+          {% else %}
+            Previous
+          {% endif %}
+          |
+          {% if page.next %}
+            <a href="{{ site.baseurl }}{{ page.next.url }}">Next</a>
+          {% else %}
+            Next
+          {% endif %}
+          </div>
+
+          <div class="return">
+            <a href="{{ site.baseurl }}/blog.html">All blog posts</a>
+          </div>
       </section>
     </div>
 

--- a/blog.md
+++ b/blog.md
@@ -1,0 +1,14 @@
+---
+layout: page
+title: Blog
+---
+
+# Blog
+
+{% if site.posts == empty %}
+<p>Coming soon</p>
+{% else %}
+{% for post in site.posts %}
+<div class="blogtitle"><a href="{{ site.baseurl }}{{ post.url }}">{{ post.title }}</a> <span>{{ post.date| date: "%A %e %B %Y" }}</span></div>
+{% endfor %}
+{% endif %}

--- a/stylesheets/stylesheet.css
+++ b/stylesheets/stylesheet.css
@@ -120,6 +120,10 @@ a {
 
 a:hover, a:focus {text-decoration: underline;}
 
+h1 a, h2 a, h3 a, h4 a {
+  color:#222222;
+}
+
 footer a {
   color: #F2F2F2;
   text-decoration: underline;
@@ -401,7 +405,33 @@ Full-Width Styles
   background: #212121;
 }
 
+.blogtitle {
+  font-size: 20px;
+}
 
+.blogtitle span {
+  padding-left: 10px;
+  font-style: normal;
+  font-size: 0.70em;
+}
+
+.blogpost h1 {
+  margin-bottom: 0;
+}
+
+.meta {
+  font-size: 0.8em;
+  color: #333;
+  margin-bottom: 10px;
+}
+
+.prevnext, .return {
+  width: 49%;
+  display: inline-block;
+}
+.return {
+  text-align: right;
+}
 
 /*******************************************************************************
 Small Device Styles


### PR DESCRIPTION
Add a new blog tab which lists all blog posts in reverse chronological
order. Each blog entry lives in the _posts directoy with information in
README.md on how to create new posts.

Note that there are no actual blog posts in this PR, so I've set the blog list page to display "Coming soon" in blog.md. This will automatically be replaced by the list of posts when they are added.

Screenshots:
List of posts: http://i.19ft.com/d3867600.png
Post page: http://i.19ft.com/589ceae4.png